### PR TITLE
Plotting

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,9 @@
+Pint-pandas is written and maintained by Hernan E. Grecco <hernan.grecco@gmail.com>.
+
+Other contributors, listed alphabetically, are:
+
+* Andrew Savage <andrewgsavage@gmail.com>
+* Sigvald Marholm <sigvald@marebakken.com>
+* Zebedee Nicholls <zebedee.nicholls@climate-energy-college.org>
+
+(If you think that your name belongs here, please let the maintainer know)

--- a/pintpandas/pint_array.py
+++ b/pintpandas/pint_array.py
@@ -27,7 +27,7 @@ from pandas.api.types import (
     is_integer,
     is_bool,
     )
-from pandas.compat import u, set_function_name
+from pandas.compat import set_function_name
 from pandas.io.formats.printing import (
     format_object_summary, format_object_attrs, default_pprint)
 from pandas import Series, DataFrame
@@ -258,10 +258,10 @@ class PintArray(ExtensionArray, ExtensionOpsMixin):
         attrs = format_object_attrs(self)
         space = " "
 
-        prepr = (u(",%s") %
-                 space).join(u("%s=%s") % (k, v) for k, v in attrs)
+        prepr = (",%s" %
+                 space).join("%s=%s" % (k, v) for k, v in attrs)
 
-        res = u("%s(%s%s)") % (klass, data, prepr)
+        res = "%s(%s%s)" % (klass, data, prepr)
 
         return res
 		


### PR DESCRIPTION
Trouble plotting dataframes using `df.length.plot()` is reported in issue https://github.com/hgrecco/pint-pandas/issues/9. This is addressed in issue https://github.com/pandas-dev/pandas/pull/25590 and is therefore expected to work at pandas 0.25. I tried using pandas 0.25.0.dev0+323.gd40446044, however, pint-pandas currently uses `pandas.compat.u()` which is removed in pandas 0.25 along with support for Python2. See https://github.com/pandas-dev/pandas/pull/25852. This PR fixes that, allowing plotting when pandas 0.25 is released (unless any conflicting changes takes place in the meantime). Pandas 0.25 is due May 1.