### PR TITLE
Misc Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ python:
 install:
   - pip install --upgrade pip
   - pip install --upgrade pytest  # pre installed version too old
+  - pip install --upgrade six
   - pip install -e .[test]
 
 script:

--- a/pintpandas/pint_array.py
+++ b/pintpandas/pint_array.py
@@ -188,8 +188,6 @@ class PintArray(ExtensionArray, ExtensionOpsMixin):
         self._dtype = dtype
         if len(values)==0:
             data_dtype = "float"
-        else:
-            data_dtype = type(values[0])
         self._data = np.array(values, data_dtype)
     
     @property

--- a/pintpandas/pint_array.py
+++ b/pintpandas/pint_array.py
@@ -27,11 +27,13 @@ from pandas.api.types import (
     is_integer,
     is_bool,
     )
-from pandas.compat import u, set_function_name
+from pandas.compat import set_function_name
 from pandas.io.formats.printing import (
     format_object_summary, format_object_attrs, default_pprint)
 from pandas import Series, DataFrame
-from pandas import compat
+
+import six as compat
+u = compat.u
 
 class PintType(ExtensionDtype):
     """

--- a/pintpandas/pint_array.py
+++ b/pintpandas/pint_array.py
@@ -136,7 +136,7 @@ class PintType(ExtensionDtype):
     def __eq__(self, other):
         try:
             other = PintType(other)
-        except ValueError:
+        except (ValueError, pint.UndefinedUnitError):
             return False
         return self.units == other.units
 

--- a/pintpandas/pint_array.py
+++ b/pintpandas/pint_array.py
@@ -180,18 +180,22 @@ class PintArray(ExtensionArray, ExtensionOpsMixin):
         
     
     def __init__(self, values, dtype=None, copy=False, data_dtype=None):
-        if dtype is None:
-            raise NotImplementedError
-        
-        if not isinstance(dtype, PintType):
-            dtype = PintType(dtype)
-        self._dtype = dtype
-        if isinstance(values, np.ndarray) and values.dtype == object:
-            self._data = np.array(list(values))
+        if isinstance(values, _Quantity):
+            self._data = values.m.copy()
+            self._dtype = PintType(values.u)
         else:
-            if len(values)==0:
-                data_dtype = "float"
-            self._data = np.array(values, data_dtype)
+            if dtype is None:
+                raise NotImplementedError
+
+            if not isinstance(dtype, PintType):
+                dtype = PintType(dtype)
+            self._dtype = dtype
+            if isinstance(values, np.ndarray) and values.dtype == object:
+                self._data = np.array(list(values))
+            else:
+                if len(values)==0:
+                    data_dtype = "float"
+                self._data = np.array(values, data_dtype)
 
     @property
     def dtype(self):

--- a/pintpandas/pint_array.py
+++ b/pintpandas/pint_array.py
@@ -186,10 +186,13 @@ class PintArray(ExtensionArray, ExtensionOpsMixin):
         if not isinstance(dtype, PintType):
             dtype = PintType(dtype)
         self._dtype = dtype
-        if len(values)==0:
-            data_dtype = "float"
-        self._data = np.array(values, data_dtype)
-    
+        if isinstance(values, np.ndarray) and values.dtype == object:
+            self._data = np.array(list(values))
+        else:
+            if len(values)==0:
+                data_dtype = "float"
+            self._data = np.array(values, data_dtype)
+
     @property
     def dtype(self):
         # type: () -> ExtensionDtype

--- a/pintpandas/test_pandas_interface.py
+++ b/pintpandas/test_pandas_interface.py
@@ -26,6 +26,10 @@ from pintpandas import PintArray
 ureg = pint.UnitRegistry()
 
 
+@pytest.fixture
+def data_for_twos():
+    return ppi.PintArray.from_1darray_quantity(([2] * 100) * ureg.meter)
+
 @pytest.fixture(params=[True, False])
 def box_in_series(request):
     """Whether to box the data in a Series"""

--- a/pintpandas/test_pandas_interface.py
+++ b/pintpandas/test_pandas_interface.py
@@ -12,9 +12,10 @@ import pintpandas as ppi
 from pint.testsuite import helpers
 
 import pandas as pd
-from pandas.compat import PY3
 from pandas.tests.extension import base
 from pandas.core import ops
+
+from six import PY3
 
 
 from pint.testsuite.test_quantity import QuantityTestCase

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ __doc__ = long_description
 
 install_requirements = [
     "pint",
+    "six",
     "pandas>=0.24.0rc1",
 ]
 


### PR DESCRIPTION
- pandas dropped <del>python3</del> (Update: I meant python2, of course) support so the `u` unicode shim is no longer available. Adopt six as a dep instead.
- `PintArray` Constructor is too naive about guessing dtype, let numpy do it instead. For Example
```python
PintArray([1, 3.14592], "g")
```
should create a float ndarray, not an int one (based on the first value)