### PR TITLE
Make PintTypes use pint.get_application_registry

### DIFF
--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -55,7 +55,7 @@ class PintType(ExtensionDtype):
     _metadata = ("units",)
     _match = re.compile(r"(P|p)int\[(?P<units>.+)\]")
     _cache = {}
-    ureg = pint.UnitRegistry()
+    ureg = pint.get_application_registry()
 
     @property
     def _is_numeric(self):


### PR DESCRIPTION
If the user defines pint._APP_REGISTRY (pint.set_application_registry) PintType.ureg will be that registry.  Otherwise it will be the default registry defined with "default_en.txt"

This provides a means of guaranteeing PintTypes will use the same UnitRegistry. 