### PR TITLE
Fix Pandas 1.2 compat

### DIFF
--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -2,8 +2,8 @@ import copy
 import re
 
 import numpy as np
-import pint
 import pandas as pd
+import pint
 from pandas import DataFrame, Series
 from pandas.api.extensions import (
     ExtensionArray,
@@ -13,10 +13,10 @@ from pandas.api.extensions import (
     register_series_accessor,
 )
 from pandas.api.types import is_integer, is_list_like, is_scalar
-from pandas.compat import set_function_name
 from pandas.arrays import BooleanArray, IntegerArray
+from pandas.compat import set_function_name
 from pandas.core.arrays.base import ExtensionOpsMixin
-from pint import errors, compat
+from pint import compat, errors
 from pint.quantity import _Quantity
 from pint.unit import _Unit
 
@@ -27,15 +27,21 @@ def convert_indexing_key(key):
 
     elif isinstance(key, IntegerArray):
         if pd.isna(key).any():
-            raise ValueError("Cannot index with an integer indexer containing NA values")
+            raise ValueError(
+                "Cannot index with an integer indexer containing NA values"
+            )
         return key.to_numpy(dtype=np.int)
 
     elif isinstance(key, (list, tuple)):
         if all(isinstance(val, bool) for val in key if val is not pd.NA):
-            return np.asarray([(False if val is pd.NA else val) for val in key], dtype=np.bool)
+            return np.asarray(
+                [(False if val is pd.NA else val) for val in key], dtype=np.bool
+            )
         if all(isinstance(val, int) for val in key if val is not pd.NA):
             if any(val is pd.NA for val in key):
-                raise ValueError("Cannot index with an integer indexer containing NA values")
+                raise ValueError(
+                    "Cannot index with an integer indexer containing NA values"
+                )
             return np.asarray([val for val in key if val is not pd.NA], dtype=np.int)
 
     return key

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -14,7 +14,6 @@ from pandas.api.extensions import (
 )
 from pandas.api.types import is_integer, is_list_like, is_scalar
 from pandas.compat import set_function_name
-from pandas.core import ops
 from pandas.arrays import BooleanArray, IntegerArray
 from pandas.core.arrays.base import ExtensionOpsMixin
 from pint import errors, compat
@@ -614,7 +613,7 @@ class PintArray(ExtensionArray, ExtensionOpsMixin):
 
             return res
 
-        op_name = ops._get_op_name(op, True)
+        op_name = f"__{op}__"
         return set_function_name(_binop, op_name, cls)
 
     @classmethod

--- a/pint_pandas/testsuite/test_pandas_interface.py
+++ b/pint_pandas/testsuite/test_pandas_interface.py
@@ -4,7 +4,6 @@ from os.path import dirname, join
 import numpy as np
 import pandas as pd
 import pint
-import pint_pandas as ppi
 import pytest
 from pandas.core import ops
 from pandas.tests.extension import base
@@ -18,6 +17,8 @@ from pandas.tests.extension.conftest import (  # noqa F401
 )
 from pint.errors import DimensionalityError
 from pint.testsuite.test_quantity import QuantityTestCase
+
+import pint_pandas as ppi
 from pint_pandas import PintArray
 
 ureg = pint.UnitRegistry()

--- a/pint_pandas/testsuite/test_pandas_interface.py
+++ b/pint_pandas/testsuite/test_pandas_interface.py
@@ -45,10 +45,14 @@ def data():
 def data_missing():
     return ppi.PintArray.from_1darray_quantity([np.nan, 1] * ureg.meter)
 
+
 @pytest.fixture
 def data_for_twos():
-    x = [2, ] * 100
+    x = [
+        2,
+    ] * 100
     return ppi.PintArray.from_1darray_quantity(x * ureg.meter)
+
 
 @pytest.fixture(params=["data", "data_missing"])
 def all_data(request, data, data_missing):
@@ -85,8 +89,7 @@ def data_missing_for_sorting():
 
 @pytest.fixture
 def na_cmp():
-    """Binary operator for comparing NA values.
-    """
+    """Binary operator for comparing NA values."""
     return lambda x, y: bool(np.isnan(x.magnitude)) & bool(np.isnan(y.magnitude))
 
 
@@ -468,7 +471,10 @@ class TestDataFrameAccessor(object):
             names=["Car type", "metric", "unit"],
         )
         df.index = pd.MultiIndex.from_arrays(
-            [[1, 12, 32, 48], ["Tim", "Tim", "Jane", "Steve"],],  # noqa E231
+            [
+                [1, 12, 32, 48],
+                ["Tim", "Tim", "Jane", "Steve"],
+            ],  # noqa E231
             names=["Measurement number", "Measurer"],
         )
 


### PR DESCRIPTION
Closes #51

`get_op_name` was removed in
https://github.com/pandas-dev/pandas/commit/89cc5bf901fc3

```
def _get_op_name(op, special: bool) -> str:
    opname = op.__name__.strip("_")
    if special:
        opname = f"__{opname}__"
    return opname
```

This replaces the 'special' case used in pint-pandas.