### PR TITLE
Fix pandas iter issues

### DIFF
--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -262,7 +262,15 @@ class PintArray(ExtensionArray, ExtensionOpsMixin):
         elif is_list_like(value) and isinstance(value[0], _Quantity):
             value = [item.to(self.units).magnitude for item in value]
 
+        # _is_scalar = is_scalar(value)
+        # if _is_scalar:
+        #     value = [value]
+        # # why the same if clause again?
+        # if _is_scalar:
+        #     value = value[0]
+
         key = convert_indexing_key(key)
+
         try:
             self._data[key] = value
         except IndexError as e:

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -628,6 +628,8 @@ class PintArray(ExtensionArray, ExtensionOpsMixin):
             return res
 
         op_name = f"__{op}__"
+        # op_name = f"__{op.__name__.strip('_')}__"
+
         return set_function_name(_binop, op_name, cls)
 
     @classmethod


### PR DESCRIPTION
This is a bit fiddly. Because there's lots of moving parts, I'm using:

pint 0.16.2.dev54+gb36d0a6
pandas https://github.com/znicholls/pandas/commit/334e69c46371c5cbad80fcbc64c192cd72a6575e

Long-story short, fixing the pandas iter issues means we can fix some of our tests, not all.

I think we should keep this as a draft until we address #40 