### PR TITLE
pint 0.21 and nanops support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ pint-pandas Changelog
 0.4 (unreleased)
 ----------------
 
-- Support for <NA> values in columns with integer magnitudes 
+- Support for <NA> values in columns with integer magnitudes
 - Support for magnitudes of any type, such as complex128 or tuples #146
 - Support for Pint 0.21 #168, #179
 

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ pint-pandas Changelog
 - Support for <NA> values in columns with integer magnitudes
 - Support for magnitudes of any type, such as complex128 or tuples #146
 - Support for Pint 0.21 #168, #179
+- Cast to `numpy.ndarray` in `PintArray._reduce` if needed to use `nanops` functions
 
 0.3 (2022-11-14)
 ----------------


### PR DESCRIPTION
This PR tries to support `pint 0.21`. This PR also considers a strange behavior that was not appreciated in minor pandas versions. 

The module `pandas.core.nanops` is supposed to act on numpy ndarrays, that's why in the test `TestGroupby.test_in_numeric_groupby` we were getting the index containing the column `"C"` only. Minor pandas versions were not raising errors and they were just omitting the column passed to the `nanops` functions, but now `pandas >=1.5.3` is raising error. To solve this i added a `numpy_data` property that tries to pass numpy ndarrays to the `nanops` functions






