### PR TITLE
Fix up pint 0.21 and re-enable tests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ pint-pandas Changelog
 
 - Support for <NA> values in columns with integer magnitudes 
 - Support for magnitudes of any type, such as complex128 or tuples #146
-- Support for Pint 0.21 #168
+- Support for Pint 0.21 #168, #179
 
 0.3 (2022-11-14)
 ----------------

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -1037,6 +1037,7 @@ try:
     # for pint < 0.21 we need to explicitly register
     compat.upcast_types.append(PintArray)
 except AttributeError:
-    # for pint = 0.21 we need to add the full name, which is to be added in pint > 0.21
-    compat.upcast_type_map.setdefault("pint_pandas.pint_array.PintArray", None)
-    pass
+    # for pint = 0.21 we need to add the full names of PintArray and DataFrame,
+    # which is to be added in pint > 0.21
+    compat.upcast_type_map.setdefault("pint_pandas.pint_array.PintArray", PintArray)
+    compat.upcast_type_map.setdefault("pandas.core.frame.DataFrame", DataFrame)

--- a/pint_pandas/testsuite/test_pandas_extensiontests.py
+++ b/pint_pandas/testsuite/test_pandas_extensiontests.py
@@ -313,7 +313,6 @@ class TestGroupby(base.BaseGroupbyTests):
 
 
 class TestInterface(base.BaseInterfaceTests):
-    @pytest.mark.xfail(run=True, reason="incompatible with Pint 0.21")
     def test_contains(self, data, data_missing):
         base.BaseInterfaceTests.test_contains(self, data, data_missing)
 
@@ -352,7 +351,6 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
     def test_divmod_series_array(self, data, data_for_twos):
         base.BaseArithmeticOpsTests.test_divmod_series_array(self, data, data_for_twos)
 
-    @pytest.mark.xfail(run=True, reason="incompatible with Pint 0.21")
     def test_arith_series_with_scalar(self, data, all_arithmetic_operators):
         # With Pint 0.21, series and scalar need to have compatible units for
         # the arithmetic to work
@@ -367,7 +365,6 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
         ser = pd.Series(data)
         self.check_opname(ser, op_name, pd.Series([ser.iloc[0]] * len(ser)), exc)
 
-    @pytest.mark.xfail(run=True, reason="incompatible with Pint 0.21")
     def test_arith_frame_with_scalar(self, data, all_arithmetic_operators):
         # frame & scalar
         op_name, exc = self._get_exception(data, all_arithmetic_operators)
@@ -396,7 +393,6 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         other = data[0]
         self._compare_other(s, data, op_name, other)
 
-    @pytest.mark.xfail(run=True, reason="incompatible with Pint 0.21")
     def test_compare_array(self, data, all_compare_operators):
         # nb this compares an quantity containing array
         # eg Q_([1,2],"m")


### PR DESCRIPTION
Adds the full name of DataFrame to `upcast_type_map` (as a backport of https://github.com/hgrecco/pint/pull/1777) and re-enables most tests marked xfail in #168, except for the groupby with extension arrays one, which still fails with pandas>=2.0, until one of #172, #176 or #178 is in.

- [ ] ~Closes # (insert issue number)~ Issues are already closed
- [x] Executed ``pre-commit run --all-files`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] ~Documented in docs/ as appropriate~
- [x] Added an entry to the CHANGES file
