### PR TITLE
Explicitly declare `units` field in PintType

### DIFF
--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -2,6 +2,7 @@ import copy
 import re
 import warnings
 from importlib.metadata import version
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -43,6 +44,7 @@ class PintType(ExtensionDtype):
     # str = '|O08'
     # base = np.dtype('O')
     # num = 102
+    units: Optional[_Unit] = None  # Filled in by `construct_from_..._string`
     _metadata = ("units",)
     _match = re.compile(r"(P|p)int\[(?P<units>.+)\]")
     _cache = {}


### PR DESCRIPTION
Improve mypy compatibility by declaring `units` to be a field of PintType.

- [ ] Closes #213
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

I don't believe this change is docs-worthy, as it doesn't change any user-visible functionality (other than to make mypy more accepting of accessing the `units` field of `PintType`).  It is implicitly covered by automated unit tests because it changes no functionality the unit tests were written to test.