### PR TITLE
Enable mypy in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,16 @@ repos:
     hooks:
       - id: nbstripout
         args: [--extra-keys=metadata.kernelspec metadata.language_info.version]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.8.0"
+    hooks:
+      - id: mypy
+        verbose: true
+        args: ["--ignore-missing-imports", "--show-error-codes"]
+        additional_dependencies: [
+          "types-requests",
+          "pandas-stubs",
+          "pint",
+          "matplotlib-stubs",
+          "itr",
+        ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: nbstripout
         args: [--extra-keys=metadata.kernelspec metadata.language_info.version]
-  - repo: https://github.com/pre-commit/mirrors-mypy
+-   repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.8.0"
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,5 +39,4 @@ repos:
           "pandas-stubs",
           "pint",
           "matplotlib-stubs",
-          "itr",
         ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import datetime
-from importlib.metadata import version
+from importlib.metadata import version as metadata_version
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -22,7 +22,7 @@ author = "Hernan E. Grecco"
 # built documents.
 
 try:  # pragma: no cover
-    version = version(project)
+    version = metadata_version(project)
 except Exception:  # pragma: no cover
     # we seem to have a local copy not installed without setuptools
     # so the reported version will be unknown

--- a/pint_pandas/__init__.py
+++ b/pint_pandas/__init__.py
@@ -6,7 +6,7 @@ try:
     from importlib.metadata import version
 except ImportError:
     # Backport for Python < 3.8
-    from importlib_metadata import version
+    from importlib_metadata import version  # type: ignore
 
 try:  # pragma: no cover
     __version__ = version("pint_pandas")

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -2,7 +2,7 @@ import copy
 import re
 import warnings
 from importlib.metadata import version
-from typing import Any, Callable, Dict, Optional, cast
+from typing import Any, Callable, Dict, Optional, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -622,7 +622,7 @@ class PintArray(ExtensionArray, ExtensionScalarOpsMixin):
         data = self._data
         return self._from_sequence(unique(data), dtype=self.dtype)
 
-    def __contains__(self, item) -> bool | np.bool_:
+    def __contains__(self, item) -> Union[bool, np.bool_]:
         if not isinstance(item, _Quantity):
             return False
         elif pd.isna(item.magnitude):

--- a/pint_pandas/testsuite/test_pandas_extensiontests.py
+++ b/pint_pandas/testsuite/test_pandas_extensiontests.py
@@ -18,7 +18,6 @@ from pandas.tests.extension.conftest import (
     use_numpy,  # noqa: F401
 )
 
-
 from pint.errors import DimensionalityError
 
 from pint_pandas import PintArray, PintType
@@ -381,9 +380,10 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
                 return TypeError
             if isinstance(obj, pd.Series):
                 try:
-                    if obj.pint.m.dtype.kind == "c":
+                    # PintSeriesAccessor is dynamically constructed; need stubs to make it mypy-compatible
+                    if obj.pint.m.dtype.kind == "c":  # type: ignore
                         pytest.skip(
-                            f"{obj.pint.m.dtype.name} {obj.dtype} does not support {op_name}"
+                            f"{obj.pint.m.dtype.name} {obj.dtype} does not support {op_name}"  # type: ignore
                         )
                         return TypeError
                 except AttributeError:
@@ -392,9 +392,9 @@ class TestArithmeticOps(base.BaseArithmeticOpsTests):
                         return exc
             if isinstance(other, pd.Series):
                 try:
-                    if other.pint.m.dtype.kind == "c":
+                    if other.pint.m.dtype.kind == "c":  # type: ignore
                         pytest.skip(
-                            f"{other.pint.m.dtype.name} {other.dtype} does not support {op_name}"
+                            f"{other.pint.m.dtype.name} {other.dtype} does not support {op_name}"  # type: ignore
                         )
                         return TypeError
                 except AttributeError:


### PR DESCRIPTION
Initial attempt to add mypy to pre-commit actions.

- [x] Closes #213
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

This changes no user-visible functionality.  It enables mypy type checking.  If this fails (because pre-commit exceeds certain memory limits, I have a fix for that).