### PR TITLE
Fix issue where quantify doesn't work on DataFrames containing string columns

### DIFF
--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -967,7 +967,7 @@ class PintDataFrameAccessor(object):
 
         df_new = DataFrame(
             {
-                i: PintArray(df.values[:, i], unit)
+                i: PintArray(df.iloc[:, i], unit)
                 if unit != NO_UNIT
                 else df.values[:, i]
                 for i, unit in enumerate(units.values)


### PR DESCRIPTION
I'm hoping someone can help me a bit. I've never contributed to an open source project and am not sure what the protocol is or how to run tests so I appreciate your patience. I'd be happy to modify my request as needed. 

The simple change I made enables the `quantify` method on a DataFrame to work even if the DataFrame contains string columns. Currently this works, but there's a unintended side effect. I've included a minimal example below to show what I mean. 

```python
import pandas as pd
import pint_pandas

df = pd.DataFrame(
    {
        'power': pd.Series([1.0,2.0,3.0], dtype='pint[W]'),
        'torque': pd.Series([4.0,5.0,6.0], dtype='pint[N*m]'),
        'fruits': pd.Series(['apple', 'pear', 'kiwi'])
    }
)
df1 = df.pint.dequantify().pint.quantify(level=-1)
print(df1.power.pint.m)
```

The current code would output:
![2024-04-02_13-07-44](https://github.com/hgrecco/pint-pandas/assets/47535659/a48ea13c-499f-43f2-a02f-37e5bb8adf50)

After the update I made:
![2024-04-02_13-12-15](https://github.com/hgrecco/pint-pandas/assets/47535659/bc5e36bb-9fe2-4aaa-aec4-528f74a57513)

As can be seen, the current code converts the underlying data to an `object` data type when it should remain `float64`. This occurs because the current code takes the entire DataFrame and converts it to a 2D array before indexing (at which point the entire array is converted to `object` datatypes. My modification indexes into individual columns so that the data is never cast to a different underlying type. 

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
