### PR TITLE
Fix issue where quantify changes the type of arrays to obj if the DataFrame containes string columns

### DIFF
--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -969,7 +969,7 @@ class PintDataFrameAccessor(object):
             {
                 i: PintArray(df.iloc[:, i], unit)
                 if unit != NO_UNIT
-                else df.values[:, i]
+                else df.iloc[:, i]
                 for i, unit in enumerate(units.values)
             }
         )

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -967,9 +967,7 @@ class PintDataFrameAccessor(object):
 
         df_new = DataFrame(
             {
-                i: PintArray(df.iloc[:, i], unit)
-                if unit != NO_UNIT
-                else df.iloc[:, i]
+                i: PintArray(df.iloc[:, i], unit) if unit != NO_UNIT else df.iloc[:, i]
                 for i, unit in enumerate(units.values)
             }
         )

--- a/pint_pandas/testsuite/test_issues.py
+++ b/pint_pandas/testsuite/test_issues.py
@@ -242,3 +242,18 @@ class TestIssue217(BaseExtensionTests):
         )
         df1 = df.pint.dequantify().pint.quantify(level=-1)
         tm.assert_equal(df1.power.pint.m, df.power.pint.m)
+
+
+class TestIssue218(BaseExtensionTests):
+    def test_roundtrip(self):
+        df = pd.DataFrame(
+            {
+                "power": pd.Series([1.0, 2.0, 3.0], dtype="pint[W]"),
+                "torque": pd.Series([4.0, 5.0, 6.0], dtype="pint[N*m]"),
+                "fruits": pd.Series(["apple", "pear", "kiwi"]),
+                "float_numbers": pd.Series([1.0, 2.0, 3.0], dtype="float64"),
+                "int_numbers": pd.Series([1.0, 2.0, 3.0], dtype="int"),
+            }
+        )
+        df1 = df.pint.dequantify().pint.quantify(level=-1)
+        tm.assert_equal(df1, df, check_dtype=True)

--- a/pint_pandas/testsuite/test_issues.py
+++ b/pint_pandas/testsuite/test_issues.py
@@ -244,7 +244,7 @@ class TestIssue217(BaseExtensionTests):
         tm.assert_equal(df1.power.pint.m, df.power.pint.m)
 
 
-class TestIssue218(BaseExtensionTests):
+class TestIssue225(BaseExtensionTests):
     def test_roundtrip(self):
         df = pd.DataFrame(
             {


### PR DESCRIPTION
#217 only seems to fix the unwanted type conversion to dtype='object' for columns with units, while the same happens with numeric columns without units.

In the following example, the "something_else" column has numerical values, but no associated units:

```python
import pandas as pd
import pint_pandas

df = pd.DataFrame(
    {
        'power': pd.Series([1.0, 2.0, 3.0], dtype='pint[W]'),
        'torque': pd.Series([4.0, 5.0, 6.0], dtype='pint[N*m]'),
        'fruits': pd.Series(['apple', 'pear', 'kiwi']),
        'something_else': pd.Series([7.0, 8.0, 9.0]),
    }
)
df1 = df.pint.dequantify().pint.quantify(level=-1)

print(df.dtypes)

print(df1.dtypes)
```

1st print statement: 
![grafik](https://github.com/hgrecco/pint-pandas/assets/40823270/470ebc77-7770-4852-83cb-b49c8bc9043b)

2nd print statement: 
![grafik](https://github.com/hgrecco/pint-pandas/assets/40823270/328dc335-8296-4f76-bd8a-6d55deace658)

This is fixed by using iloc, both, for columns with and without units.


- [ ] Closes # (insert issue number)
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
