### PR TITLE
revert test skip introduced for #239

### DIFF
--- a/.github/workflows/ci-pandas-pre.yml
+++ b/.github/workflows/ci-pandas-pre.yml
@@ -9,7 +9,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
         numpy: ["numpy>=1.20.3,<2.0.0", "numpy==2.0.0.rc2"]
         pandas: ["pandas>=3.0.0"]
-        pint: ["pint==0.24"]
+        pint: ["pint>=0.24"]
 
     runs-on: ubuntu-latest
 

--- a/pint_pandas/testsuite/test_issues.py
+++ b/pint_pandas/testsuite/test_issues.py
@@ -138,7 +138,7 @@ class TestIssue80:
             t = self._timeit(getattr(s, reduction)).to("ms")
 
             if t > 0:
-                assert tp <= 5 * t
+                assert tp <= 10 * t
 
 
 def test_issue_86():

--- a/pint_pandas/testsuite/test_pandas_extensiontests.py
+++ b/pint_pandas/testsuite/test_pandas_extensiontests.py
@@ -38,14 +38,7 @@ def dtype():
 
 
 _base_numeric_dtypes = [float, int]
-if pandas_version_info <= (3, 0, 0):
-    _all_numeric_dtypes = _base_numeric_dtypes + [np.complex128]
-else:
-    # work around to make test pass in the context of GH #239
-    # complex induce NumpyExtensionArray that are not managed by
-    # latest version of pandas.core.algorithms.take
-    # https://github.com/pandas-dev/pandas/issues/59177
-    _all_numeric_dtypes = _base_numeric_dtypes
+_all_numeric_dtypes = _base_numeric_dtypes + [np.complex128]
 
 
 @pytest.fixture(params=_all_numeric_dtypes)
@@ -321,17 +314,6 @@ class TestPintArray(base.ExtensionTests):
     def _get_expected_exception(
         self, op_name: str, obj, other
     ):  #  -> type[Exception] | None, but Union types not understood by Python 3.9
-        if op_name in [
-            "__radd__",
-            "__rsub__",
-            "__rmul__",
-            "__rtruediv__",
-            "__rpow__",
-        ] and pandas_version_info >= (3, 0, 0):
-            pytest.skip(
-                f"ongoing issue with pandas >=3 with {type(obj).__name__} that does not support {op_name}. GH #239"
-            )
-            return TypeError
         if op_name in ["__pow__", "__rpow__"]:
             return DimensionalityError
 


### PR DESCRIPTION
- [x] Closes #240 
- [x] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests: hopefully with latest version of pint
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

need to wait for new release of pint after https://github.com/hgrecco/pint/pull/2036