### PR TITLE
Pr/137 compat check

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ pint-pandas Changelog
 0.7 (unreleased)
 --------------------
 
-- Nothing added yet.
+- Fix PintType._get_common_dtype (added via #137) to check compatibility of all `PintType`s in `dtypes`
 
 
 0.6.1 (2024-07-13)

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,7 @@ pint-pandas Changelog
 =====================
 
 
-0.7 (unreleased)
+0.6.2 (2024-07-29)
 --------------------
 
 - Fix PintType._get_common_dtype (added via #137) to check compatibility of all `PintType`s in `dtypes`

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -214,19 +214,18 @@ class PintType(ExtensionDtype):
         -------
         returns self for acceptable cases or None otherwise
         """
+        # Return self (PintType with same units) if possible
         if all(
-            isinstance(x, PintType) or pd.api.types.is_numeric_dtype(x) for x in dtypes
+            isinstance(dtype, PintType) and dtype.units == self.units
+            for dtype in dtypes
         ):
-            PintType_list = [x for x in dtypes if isinstance(x, PintType)]
-            if len(PintType_list) < 2:
-                return self
-            if all(
-                PintType_list[0].units.is_compatible_with(x.units)
-                for x in PintType_list[1:]
-            ):
-                return self
-            else:
-                return None
+            return self
+        # Otherwise return PintType with undefined units
+        elif all(
+            isinstance(dtype, PintType) or pd.api.types.is_numeric_dtype(dtype)
+            for dtype in dtypes
+        ):
+            return PintType
         else:
             return None
 

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -220,7 +220,10 @@ class PintType(ExtensionDtype):
             PintType_list = [x for x in dtypes if isinstance(x, PintType)]
             if len(PintType_list) < 2:
                 return self
-            if all (PintType_list[0].units.is_compatible_with(x.units) for x in PintType_list[1:]):
+            if all(
+                PintType_list[0].units.is_compatible_with(x.units)
+                for x in PintType_list[1:]
+            ):
                 return self
             else:
                 return None

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -203,6 +203,7 @@ class PintType(ExtensionDtype):
 
         In order to be able to be able to perform operation on ``PintType``
         with scalars, mix of ``PintType`` and numeric values are allowed.
+        But all ``PintType`` elements must be compatible.
 
 
         Parameters
@@ -216,7 +217,13 @@ class PintType(ExtensionDtype):
         if all(
             isinstance(x, PintType) or pd.api.types.is_numeric_dtype(x) for x in dtypes
         ):
-            return self
+            PintType_list = [x for x in dtypes if isinstance(x, PintType)]
+            if len(PintType_list) < 2:
+                return self
+            if all (PintType_list[0].units.is_compatible_with(x.units) for x in PintType_list[1:]):
+                return self
+            else:
+                return None
         else:
             return None
 

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -201,7 +201,7 @@ class PintType(ExtensionDtype):
         If this function is called this means at least on of the ``dtypes``
         list is a ``PintType``
 
-        In order to be able to be able to perform operation on ``PintType``
+        In order to be able to perform operation on ``PintType``
         with scalars, mix of ``PintType`` and numeric values are allowed.
         But all ``PintType`` elements must be compatible.
 

--- a/pint_pandas/testsuite/test_issues.py
+++ b/pint_pandas/testsuite/test_issues.py
@@ -277,6 +277,7 @@ class TestIssue137(BaseExtensionTests):
         )
         tm.assert_series_equal(df.eval("a / b"), df["a"] / df["b"])
         tm.assert_series_equal(df.eval("a / c"), df["a"] / df["c"])
+        tm.assert_series_equal(df.eval("a / a"), df["a"] / df["a"])
 
     def test_mixed_df(self):
         df = pd.DataFrame(
@@ -287,4 +288,26 @@ class TestIssue137(BaseExtensionTests):
             }
         )
 
-        assert df["a"][0] == df.iloc[0][0]
+        assert df["a"][0] == df.iloc[0, 0]
+
+
+class TestIssue246(BaseExtensionTests):
+    def test_issue246(self):
+        df = pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+                "b": [4, 5, 6],
+                "c": [7, 8, 9],
+            }
+        )
+
+        df = df.astype(
+            {
+                "a": "pint[m]",
+                "b": "pint[m/s]",
+                "c": "pint[kN]",
+            }
+        )
+
+        # now an operation where each cell is independent from each other
+        df.apply(lambda x: x * 2, axis=1)

--- a/pint_pandas/testsuite/test_issues.py
+++ b/pint_pandas/testsuite/test_issues.py
@@ -277,3 +277,14 @@ class TestIssue137(BaseExtensionTests):
         )
         tm.assert_series_equal(df.eval("a / b"), df["a"] / df["b"])
         tm.assert_series_equal(df.eval("a / c"), df["a"] / df["c"])
+
+    def test_mixed_df(self):
+        df = pd.DataFrame(
+            {
+                "a": pd.Series([1.0, 2.0, 3.0], dtype="pint[meter]"),
+                "b": pd.Series([4.0, 5.0, 6.0], dtype="pint[second]"),
+                "c": [1.0, 2.0, 3.0],
+            }
+        )
+
+        assert df["a"][0] == df.iloc[0][0]


### PR DESCRIPTION
PR number 137 adds _get_common_dtype to PintType so that `PintType` operations can be performed on a mix of `PintType` and numeric values (with the later being promoted to the `PintType` for the purposes of the operation). However, when there are multiple `PintType` elements present, it is important that all elements are in fact compatible, lest the operation attempt to combine two `PintType` elements that are not unit-compatible.

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
