### PR TITLE
allow missing values in columns

### DIFF
--- a/pint_pandas/testsuite/test_issues.py
+++ b/pint_pandas/testsuite/test_issues.py
@@ -1,4 +1,6 @@
+import io
 import pickle
+from textwrap import dedent
 import time
 
 import numpy as np
@@ -344,3 +346,17 @@ class TestIssue247(BaseExtensionTests):
     result = a / a
     expected = pd.Series([1, 1, 1], dtype="pint[][Float64]")
     tm.assert_series_equal(result, expected)
+
+
+class TestIssue267(BaseExtensionTests):
+    def test_missing_values(self):
+        "make sure that a missing values don't prevent the column from being imported"
+        data = dedent(
+            """\
+            mass
+            1,1lb
+            2,
+            """
+        )
+        df = pd.read_csv(io.StringIO(data), dtype=dict(mass="pint[kg]"))
+        assert df["mass"].dtype == PintType("kg")

--- a/pint_pandas/testsuite/test_issues.py
+++ b/pint_pandas/testsuite/test_issues.py
@@ -354,9 +354,13 @@ class TestIssue267(BaseExtensionTests):
         data = dedent(
             """\
             mass
-            1,1lb
-            2,
+            0,1lb
+            1,
             """
         )
         df = pd.read_csv(io.StringIO(data), dtype=dict(mass="pint[kg]"))
-        assert df["mass"].dtype == PintType("kg")
+        mass = df["mass"]
+        assert mass.dtype == PintType("kg")
+
+        missing = pd.Series([False, True], name="mass")
+        tm.assert_equal(pd.isna(mass), missing)


### PR DESCRIPTION
Previously the code would fail with:
```none
DimensionalityError: Cannot convert from 'dimensionless' (dimensionless) to 'someunit' ([somedimension]).
```
if any of the values were missing.  It seems much nicer if they were maintained as missing values of appropriate unit.

- [x] Partial fix for #267 
- [x] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
