### PR TITLE
just rstrip suffix rather than splitting on it in case it's empty

### DIFF
--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -1128,7 +1128,7 @@ register_extension_dtype(PintType)
 
 def _parse_column_name(column_name, seperator, suffix):
     if seperator in column_name:
-        return column_name.split(suffix)[0].split(seperator)
+        return column_name.rstrip(suffix).split(seperator)
     return column_name, NO_UNIT
 
 


### PR DESCRIPTION
In the quantity calculus, the style is "time / s", so that `suffix=""`, which is empty and `str.strip` rejects an empty `sep` with a `TypeError`.