### PR TITLE
Fix inplace accessors (Issue #282)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ pint-pandas Changelog
 
 - `Dataframe.pint.quantify` and `Dataframe.pint.dequantify` will now accept and return single row headers,
   allowing it to parse column names such as `torque [lbf in]`.
+- Fix inplace accessor methods (ito(), etc.; Issue #282)
 
 0.7.1 (2025-01-06)
 --------------------

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -1384,6 +1384,7 @@ class DelegatedMethod(Delegated):
 class DelegatedScalarMethod(DelegatedMethod):
     to_series = False
 
+
 class DelegatedInplaceMethod(DelegatedMethod):
     to_series = False
     reinitialize = True

--- a/pint_pandas/testsuite/test_pandas_interface.py
+++ b/pint_pandas/testsuite/test_pandas_interface.py
@@ -377,8 +377,9 @@ class TestSeriesAccessors(object):
 
         s = pd.Series(deepcopy(data))
         getattr(s.pint, attr)(*args)
-        getattr(data.quantity, attr)(*args)
-        assert all(s.values == data)
+        q = data.quantity
+        getattr(q, attr)(*args)
+        assert all(s.values == q)
 
     @pytest.mark.parametrize(
         "attr_args",


### PR DESCRIPTION
- Fix inplace accessor methods (ito(), etc.; Issue #282)
- Fix corresponding tests, which were wrong

- [X] Closes #282
- [X] Executed `pre-commit run --all-files` with no errors
- [X] The change is fully covered by automated unit tests
- [X] Documented in docs/ as appropriate
- [X] Added an entry to the CHANGES file