### PR TITLE
Fix mip install issue

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,7 +1,8 @@
 sphinx>=6
 ipython<=8.12
 matplotlib
-mip>=1.13
+# Install of mip crashes from Python 3.13 due to cffi dependency issue (see https://github.com/python-cffi/cffi/issues/48 and https://stackoverflow.com/questions/79463080/building-wheel-for-cffi-fails-when-installing-python-mip)
+mip>=1.13; python_version < '3.13'
 nbsphinx
 numpy
 pytest


### PR DESCRIPTION
Fix mip install issue on Python >= 3.13 as in hgrecco/pint#2198

- [ ] Closes # (insert issue number)
- [ ] Executed `pre-commit run --all-files` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
