### PR TITLE
Issue 300

### DIFF
--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -268,7 +268,7 @@ class PintType(ExtensionDtype):
             isinstance(dtype, PintType) or pd.api.types.is_numeric_dtype(dtype)
             for dtype in dtypes
         ):
-            return PintType
+            return PintType()
         else:
             return None
 

--- a/pint_pandas/pint_array.py
+++ b/pint_pandas/pint_array.py
@@ -715,7 +715,11 @@ class PintArray(ExtensionArray, ExtensionScalarOpsMixin):
             subdtype = dtype.subdtype
 
         # convert scalars to output unit
-        if isinstance(master_scalar, _Quantity):
+        if (
+            isinstance(master_scalar, _Quantity)
+            and units is not None
+            and (units != pint.Unit("dimensionless") or dtype is None)
+        ):
             scalars = [
                 (item.to(units).magnitude if hasattr(item, "to") else item)
                 for item in scalars
@@ -969,12 +973,14 @@ class PintArray(ExtensionArray, ExtensionScalarOpsMixin):
         return np.array(self._data, dtype=dtype)
 
     def _to_array_of_quantity(self, copy=False):
-        qtys = [
-            self._Q(item, self._dtype.units)
-            if not pd.isna(item)
-            else self.dtype.na_value
-            for item in self._data
-        ]
+        qtys = []
+        for item in self._data:
+            if pd.isna(item):
+                qtys.append(self.dtype.na_value)
+            elif isinstance(item, self._Q):
+                qtys.append(item)
+            else:
+                qtys.append(self._Q(item, self._dtype.units))
         with warnings.catch_warnings(record=True):
             return np.array(qtys, dtype="object")
 

--- a/pint_pandas/testsuite/test_issues.py
+++ b/pint_pandas/testsuite/test_issues.py
@@ -316,7 +316,8 @@ class TestIssue246(BaseExtensionTests):
         )
 
         # now an operation where each cell is independent from each other
-        df.apply(lambda x: x * 2, axis=1)
+        res = df.apply(lambda x: x * 2, axis=1)
+        print(res)
 
 
 class TestArrayFunction(BaseExtensionTests):
@@ -398,3 +399,20 @@ class TestIssue285(BaseExtensionTests):
         tm.assert_equal(mean_kg, mean_expected)
         tm.assert_equal(std_kg, std_expected)
         tm.assert_equal(var_kg, var_expected)
+
+
+class TestIssue300(BaseExtensionTests):
+    def test_issue300(self):
+        df = pd.DataFrame(
+            {
+                "torque": pd.Series([1.0, 2.0, 2.0, 3.0], dtype="pint[lbf ft]"),
+                "angular_velocity": pd.Series([1.0, 2.0, 2.0, 3.0], dtype="pint[rpm]"),
+            }
+        )
+        res1 = pd.Series([1.0, 4.0, 4.0, 9.0], dtype="pint[ft*lbf*rpm]")
+        test1 = df.eval("torque * angular_velocity")
+        tm.assert_series_equal(test1, res1)
+
+        res2 = pd.Series([2.0, 8.0, 8.0, 18.0], dtype="pint[ft*lbf*rpm]")
+        test2 = df.eval("torque * angular_velocity + torque * angular_velocity ")
+        tm.assert_series_equal(test2, res2)

--- a/pint_pandas/testsuite/test_issues.py
+++ b/pint_pandas/testsuite/test_issues.py
@@ -316,8 +316,7 @@ class TestIssue246(BaseExtensionTests):
         )
 
         # now an operation where each cell is independent from each other
-        res = df.apply(lambda x: x * 2, axis=1)
-        print(res)
+        df.apply(lambda x: x * 2, axis=1)
 
 
 class TestArrayFunction(BaseExtensionTests):


### PR DESCRIPTION
- [x] Closes #300
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file

`_get_common_dtype` used to return `self` (instance of PintType), `PintType` or `None` this is kind of inconsistent.

Proposed change bring more consistent return: instance of PintType or None. This  resolves #300 but breaks test introduced for #246 and #137

For the record `test_issue246` only test that `df.apply(lambda x: x * 2, axis=1)` does not raise but the result is not so satisfying IMO:

``` python
>>> df.apply(lambda x: x * 2, axis=1) 
           a                    b                c
0  2.0 meter   8.0 meter / second  14.0 kilonewton
1  4.0 meter  10.0 meter / second  16.0 kilonewton
2  6.0 meter  12.0 meter / second  18.0 kilonewton
>>> # we would expect to be equal to 2 * df
>>> 2 * df
     a     b     c
0  2.0   8.0  14.0
1  4.0  10.0  16.0
2  6.0  12.0  18.0
>>> (2 * df).dtype
a             pint[meter][Float64]
b    pint[meter / second][Float64]
c        pint[kilonewton][Float64]
dtype: object
>>> we need to go through convert_object_dtype to get what I think is the proper result
>>> tm.assert_frame_equal(df.apply(lambda x: x * 2, axis=1).pint.convert_object_dtype(), 2*df)
```